### PR TITLE
Improve error reporting

### DIFF
--- a/displaylang/build.py
+++ b/displaylang/build.py
@@ -92,7 +92,7 @@ class DisplayLangEvaluator(ExpressionEvaluator):
                 for i in address:
                     try:
                         v = v[i]
-                    except IndexError:
+                    except (IndexError, TypeError):
                         msg = 'Cannot unpack assignment.'
                         reject(msg, node)
                 self.add_current_name(target_name, v)
@@ -365,7 +365,7 @@ class DisplayLangProcessor:
             # We want such exceptions to be wrapped in `ControlledEvaluationException`
             # and re-raised in this form.
             except Exception as e:
-                raise ControlledEvaluationException(str(e)) from e
+                raise ControlledEvaluationException(repr(e)) from e
             if isinstance(result, ast.Return):
                 val = result.value
                 if not isinstance(val, str):


### PR DESCRIPTION
Fixes #2
Fixes #3 

Resolves two issues:

* Uses `repr` instead of `str` to get more descriptive error messages, in general.

* Catches both `IndexError` and `TypeError` when visiting assignments, for better error message when cannot unpack.